### PR TITLE
docs: lead Quick start with browser example before Node

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,6 +12,28 @@ For HTML authoring guidance (what converts well), see [AGENTS.md](./AGENTS.md). 
 npm install dom-docx
 ```
 
+### Browser
+
+```typescript
+import { convertHtmlToDocx } from "dom-docx/browser";
+
+const html = `
+<h1 style="color:#1a1a2e">Quarterly Report</h1>
+<p>Revenue grew <strong>12%</strong> year over year.</p>
+<ul>
+  <li>North America</li>
+  <li>EMEA</li>
+</ul>
+`;
+
+const blob = await convertHtmlToDocx(html);
+// hand the Blob to a download (e.g. saveAs(blob, "output.docx"))
+```
+
+Runs entirely in the user's tab — **no Playwright, no Node `Buffer`**. See the browser entry point section below for the full API.
+
+### Node
+
 ```typescript
 import { writeFile } from "node:fs/promises";
 import { convertHtmlToDocx } from "dom-docx";

--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ Input is a **body HTML fragment**, same as the API. `--help` for all options.
 
 ## Quick start
 
+### Browser
+
+```typescript
+import { convertHtmlToDocx } from "dom-docx/browser";
+
+const html = `
+<h1 style="color:#1a1a2e">Quarterly Report</h1>
+<p>Revenue grew <strong>12%</strong> year over year.</p>
+<ul>
+  <li>North America</li>
+  <li>EMEA</li>
+</ul>
+`;
+
+const blob = await convertHtmlToDocx(html);
+// e.g. trigger a download in the browser
+const a = document.createElement("a");
+a.href = URL.createObjectURL(blob);
+a.download = "output.docx";
+a.click();
+```
+
+No Playwright, no Node — this runs entirely in the user's tab. See [Browser bundle](#browser-bundle) below.
+
+### Node
+
 ```typescript
 import { writeFile } from "node:fs/promises";
 import { convertHtmlToDocx } from "dom-docx";


### PR DESCRIPTION
Reorders README and API.md Quick start sections so the browser
(dom-docx/browser) snippet comes first, followed by the Node example.